### PR TITLE
simplify the template to include all logs from the docker directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,9 @@ WORKDIR /app
 # clear logrotate ubuntu installation and modify logrotate script
 # add the template and enable debug mode
 RUN rm /etc/logrotate.d/* \
-    && cp /app/logrotate.tmpl /etc/logrotate.d/docker \
-    && chmod 0644 /etc/logrotate.d/docker \
     && sed -i \
     -e 's/^\/usr\/sbin\/logrotate.*/\/usr\/sbin\/logrotate \-v \/etc\/logrotate.conf/' \
-    /etc/cron.daily/logrotate
+    /etc/cron.daily/logrotate \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 # set default configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN rm /etc/logrotate.d/* \
     && sed -i \
     -e 's/^\/usr\/sbin\/logrotate.*/\/usr\/sbin\/logrotate \-v \/etc\/logrotate.conf/' \
     /etc/cron.daily/logrotate
-    #&& apt-get clean \
-    #&& rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 # set default configuration
 ENV DOCKER_DIR /var/lib/docker/
 ENV GOCRON_SCHEDULER 0 0 * * * *

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ MAINTAINER Michal Raczka me@michaloo.net
 RUN apt-get update \
     && apt-get install -y curl
 
-# install docker-gen
-RUN curl -sL https://github.com/jwilder/docker-gen/releases/download/0.3.2/docker-gen-linux-amd64-0.3.2.tar.gz \
-    | tar -xz -C /usr/local/bin
-
 # install go-cron
 RUN curl -sL https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz \
     | tar -x -C /usr/local/bin
@@ -18,21 +14,21 @@ ADD . /app
 WORKDIR /app
 
 # clear logrotate ubuntu installation and modify logrotate script
-# add docker-gen execution and enable debug mode
-RUN rm /etc/logrotate.d/* && \
-    sed -i \
+# add the template and enable debug mode
+RUN rm /etc/logrotate.d/* \
+    && cp /app/logrotate.tmpl /etc/logrotate.d/docker \
+    && chmod 0644 /etc/logrotate.d/docker \
+    && sed -i \
     -e 's/^\/usr\/sbin\/logrotate.*/\/usr\/sbin\/logrotate \-v \/etc\/logrotate.conf/' \
-    -e '/\#\!\/bin\/sh/a /usr/local/bin/docker-gen /root/logrotate.tmpl /etc/logrotate.d/docker' \
     /etc/cron.daily/logrotate
-
+    #&& apt-get clean \
+    #&& rm -rf /var/lib/apt/lists/*
 # set default configuration
-ENV DOCKER_HOST unix:///var/run/docker.sock
 ENV DOCKER_DIR /var/lib/docker/
 ENV GOCRON_SCHEDULER 0 0 * * * *
 
 ENV LOGROTATE_MODE daily
-ENV LOGROTATE_ROTATE 3
-ENV LOGROTATE_SIZE 512M
+ENV LOGROTATE_ROTATE 7
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/app/start" ]

--- a/README.md
+++ b/README.md
@@ -2,20 +2,19 @@
 
 Docker image with golang utilities:
 
-- [docker-gen](https://github.com/jwilder/docker-gen)
 - [go-cron](https://github.com/michaloo/go-cron)
 
 which rotate logs from all docker containers.
 
-By default it runs every hour and rotate files daily or when they exceed 512M filesize.
+By default it runs every hour and rotate files daily.
 
 Logrotate interval is controlled by `GOCRON_SCHEDULER` environmental variable according to [golang cron package format](http://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format).
 
-Rotation config is created using `/app/logrotate.tmpl` docker-gen template and could be easily overwritten in custom Dockerfile:
+Rotation config is created using `/app/logrotate.tmpl` and could be easily overwritten in custom Dockerfile:
 
 `ADD my-custom-logrotate-template.tmpl /app/logrotate.tmpl`
 
 
 # Example usage
 
-`docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker michaloo/logrotate`
+`docker run -d -v /var/lib/docker:/var/lib/docker michaloo/logrotate`

--- a/logrotate.tmpl
+++ b/logrotate.tmpl
@@ -1,10 +1,8 @@
-{{ range $index, $value := $ }}
-/var/lib/docker/containers/{{ $value.ID }}/{{ $value.ID }}-json.log{{ end }}
+/var/lib/docker/containers/*/*.log
 {
     {{LOGROTATE_MODE}}
     missingok
     rotate {{LOGROTATE_ROTATE}}
-    size {{LOGROTATE_SIZE}}
     compress
     notifempty
     copytruncate

--- a/start
+++ b/start
@@ -3,6 +3,6 @@
 sed -e 's/{{LOGROTATE_MODE}}/'"$LOGROTATE_MODE"'/' \
     -e 's/{{LOGROTATE_ROTATE}}/'"$LOGROTATE_ROTATE"'/' \
     /app/logrotate.tmpl > /etc/logrotate.d/docker
-
+chmod 0644 /etc/logrotate.d/docker
 exec /usr/local/bin/go-cron "$GOCRON_SCHEDULER" /etc/cron.daily/logrotate
 

--- a/start
+++ b/start
@@ -2,8 +2,7 @@
 
 sed -e 's/{{LOGROTATE_MODE}}/'"$LOGROTATE_MODE"'/' \
     -e 's/{{LOGROTATE_ROTATE}}/'"$LOGROTATE_ROTATE"'/' \
-    -e 's/{{LOGROTATE_SIZE}}/'"$LOGROTATE_SIZE"'/' \
-    /app/logrotate.tmpl > /root/logrotate.tmpl
+    /app/logrotate.tmpl > /etc/logrotate.d/docker
 
 exec /usr/local/bin/go-cron "$GOCRON_SCHEDULER" /etc/cron.daily/logrotate
 


### PR DESCRIPTION
This way even if you start the container before all other conatiners the logroatet will always work for all logs.

Remove the size condition form the template as date and size cannot exist in the same tmeplate

Update the documentation with the changes
